### PR TITLE
cli: strcasecmp function is defined in <strings.h>

### DIFF
--- a/src/cli/linenoise.c
+++ b/src/cli/linenoise.c
@@ -111,6 +111,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>
+#include <strings.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <sys/types.h>


### PR DESCRIPTION
Getting compile time warnings
linenoise.c:213: warning: implicit declaration of function ‘strcasecmp’
linenoise.c:213: warning: nested extern declaration of ‘strcasecmp’