### PR TITLE
build: speedup build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,8 @@ message(STATUS "Building in ${CMAKE_BUILD_TYPE} mode")
 message(STATUS "Building with ${CMAKE_C_COMPILER_ID} ${CMAKE_C_COMPILER_VERSION} on ${CMAKE_SYSTEM}")
 
 set(CMAKE_C_FLAGS "$ENV{CFLAGS} -pedantic -std=c99 -Wall -Wextra -fstrict-aliasing -fno-omit-frame-pointer")
-set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS} -Werror -Wno-unused-value -O0 -g3")
-set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS} -O2 -g")
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS} -DDEBUG -Werror -Wno-unused-value -O0 -g3")
+set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS} -DNDEBUG -O2 -g")
 
 include_directories(${CMAKE_SOURCE_DIR}/include)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,8 +106,9 @@ target_include_directories(duktape
     PRIVATE ${CMAKE_SOURCE_DIR}/include/sjs
 )
 
-set_target_properties(duktape
-    PROPERTIES COMPILE_FLAGS "-fPIC -Wno-unused-function -Wno-unused-parameter"
+set_target_properties(duktape PROPERTIES
+    COMPILE_FLAGS "-Wno-unused-function -Wno-unused-parameter"
+    POSITION_INDEPENDENT_CODE ON
 )
 
 
@@ -152,46 +153,49 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     )
 endif()
 
-add_library(sjs_static STATIC ${SOURCES})
+add_library(sjs_obj OBJECT ${SOURCES})
 
-target_include_directories(sjs_static
+target_include_directories(sjs_obj
     PRIVATE ${CMAKE_SOURCE_DIR}/include/sjs
 )
+
+set_target_properties(sjs_obj PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+)
+
+if("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
+    set_target_properties(sjs_obj PROPERTIES
+        COMPILE_DEFINITIONS "_POSIX_C_SOURCE=200112"
+    )
+endif()
+
+add_library(sjs_static STATIC $<TARGET_OBJECTS:sjs_obj>)
 
 target_link_libraries(sjs_static
     duktape
     m
 )
+
 if("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
     target_link_libraries(sjs_static
         dl
         rt
     )
-    set_target_properties(sjs_static PROPERTIES
-        COMPILE_DEFINITIONS "_POSIX_C_SOURCE=200112"
-    )
 endif()
 
-add_library(sjs SHARED ${SOURCES})
-
-target_include_directories(sjs
-    PRIVATE ${CMAKE_SOURCE_DIR}/include/sjs
-)
+add_library(sjs SHARED $<TARGET_OBJECTS:sjs_obj>)
 
 target_link_libraries(sjs
     duktape
     m
 )
+
 if("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
     target_link_libraries(sjs
         dl
         rt
     )
-    set_target_properties(sjs PROPERTIES
-        COMPILE_DEFINITIONS "_POSIX_C_SOURCE=200112"
-    )
 endif()
-
 
 
 # sjs

--- a/src/bindings/io.c
+++ b/src/bindings/io.c
@@ -1,8 +1,8 @@
 
-#include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -255,7 +255,7 @@ static duk_ret_t io_setvbuf(duk_context* ctx) {
         mode = _IOLBF;
         size = BUFSIZ;
     } else {
-        assert(0);
+        abort();
     }
 
     /*

--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -316,6 +316,7 @@ static int handle_interactive(void) {
 
 
 static void handle_sigint(int sig) {
+    (void) sig;
     assert(sig == SIGINT);
     if (cli.got_sigint == 1) {
         exit(EXIT_SUCCESS);


### PR DESCRIPTION
Use an object target to avoid building libsjs sources twice.