### PR TITLE
added SO_RCVTIMEO and SO_SNDTIMEO constants to class "net", updated test

### DIFF
--- a/src/bindings/socket.c
+++ b/src/bindings/socket.c
@@ -799,6 +799,8 @@ static const duk_number_list_entry module_consts[] = {
     X(SO_OOBINLINE),
     X(SO_SNDBUF),
     X(SO_RCVBUF),
+    X(SO_SNDTIMEO),
+    X(SO_RCVTIMEO),
     X(SO_ERROR),
     X(TCP_NODELAY),
     X(TCP_KEEPCNT),

--- a/test/test-net-socket-options.js
+++ b/test/test-net-socket-options.js
@@ -45,4 +45,44 @@ resBuf = new Buffer(r);
 assert.equal(resBuf.readInt32LE(0), 0)
 assert.equal(resBuf.readInt32LE(4), 0)
 
+// test SO_SNDTIMEO and SO_RCVTIMEO
+var sndTimeout = new Buffer(16) // struct timeval is 16 bytes on 64-bit
+sndTimeout.writeInt32LE(1, 0);  // tv_sec = 1
+sndTimeout.writeInt32LE(0, 4);
+sndTimeout.writeInt32LE(0, 8);  // tv_usec = 0
+sndTimeout.writeInt32LE(0, 12);
+sock.setsockopt(net.SOL_SOCKET, net.SO_SNDTIMEO, sndTimeout.toString());
+r = sock.getsockopt(net.SOL_SOCKET,net.SO_SNDTIMEO,16);
+resBuf = new Buffer(r);
+assert.equal(resBuf.readInt32LE(0),  1);
+assert.equal(resBuf.readInt32LE(4),  0);
+assert.equal(resBuf.readInt32LE(8),  0);
+assert.equal(resBuf.readInt32LE(12), 0);
+
+var rcvTimeout = new Buffer(16) // struct timeval is 16 bytes on 64-bit
+rcvTimeout.writeInt32LE(0, 0);     // tv_sec = 0
+rcvTimeout.writeInt32LE(0, 4);
+rcvTimeout.writeInt32LE(10000, 8); // tv_usec = 10000
+rcvTimeout.writeInt32LE(0, 12);
+console.log(rcvTimeout);
+sock.setsockopt(net.SOL_SOCKET, net.SO_RCVTIMEO, rcvTimeout.toString());
+r = sock.getsockopt(net.SOL_SOCKET,net.SO_RCVTIMEO,16);
+resBuf = new Buffer(r);
+// value of getsockopt for SO_RCVTIMEO is changed by the kernel
+// for the set-value of 10000, the get-value is 12000 on my machine,
+// but I can't guarantee whatever relationship those two numbers
+// have will remain consistent from machine to machine, kernel to kernel,
+// distro to distro, etc
+// see [this StackOverflow post](https://stackoverflow.com/questions/42536919/why-so-rcvtimeo-timeout-differs-after-it-was-set)
+// so, I just check that the value isn't too far off
+var val,rx,ry
+assert.equal(resBuf.readInt32LE(0),  0);
+assert.equal(resBuf.readInt32LE(4),  0);
+val = resBuf.readInt32LE(8);
+rx = (val > (10000/2));
+ry = (val < (10000*2));
+assert.equal(rx,true);
+assert.equal(ry,true);
+assert.equal(resBuf.readInt32LE(12), 0);
+
 sock.close();


### PR DESCRIPTION
N.B.:
SO_RCVTIMEO values returned from **get**sockopt will differ from the value set by **set**sockopt
because of the way the Linux kernel interprets the fields of the `struct timeval`, see-
[this StackOverflow post](https://stackoverflow.com/questions/42536919/why-so-rcvtimeo-timeout-differs-after-it-was-set)